### PR TITLE
Fix WASM/JS memory handling bug

### DIFF
--- a/base/buddy.c
+++ b/base/buddy.c
@@ -7,6 +7,19 @@
 #include <base/mem.h>
 #include <base/exit.h>
 
+// Export buddy allocator functions for WASM JavaScript interop
+#ifdef __wasi__
+__attribute__((export_name("wasm_buddy_alloc")))
+void *wasm_buddy_alloc(size_t size) {
+    return buddy_alloc(size);
+}
+
+__attribute__((export_name("wasm_buddy_free")))
+void wasm_buddy_free(void *ptr) {
+    buddy_free(ptr);
+}
+#endif
+
 #define MIN_PAGE_SIZE 4096UL
 #define MAX_ORDER 20 // 2^20 * 4KB = 4GB
 

--- a/game.c
+++ b/game.c
@@ -1592,7 +1592,7 @@ static int complete_gpu_setup(GameApp *app) {
         SDL_Log("Failed to map vertex transfer buffer: %s", SDL_GetError());
         return -1;
     }
-    base_memmove(mapped_vertices, cpu_vertices, vertex_buffer_info.size);
+    base_memcpy(mapped_vertices, cpu_vertices, vertex_buffer_info.size);
     SDL_UnmapGPUTransferBuffer(app->device, app->scene_vertex_transfer_buffer);
 
     uint16_t *mapped_indices = (uint16_t *)SDL_MapGPUTransferBuffer(app->device, app->scene_index_transfer_buffer, false);
@@ -1600,7 +1600,7 @@ static int complete_gpu_setup(GameApp *app) {
         SDL_Log("Failed to map index transfer buffer: %s", SDL_GetError());
         return -1;
     }
-    base_memmove(mapped_indices, mesh->indices, index_buffer_info.size);
+    base_memcpy(mapped_indices, mesh->indices, index_buffer_info.size);
     SDL_UnmapGPUTransferBuffer(app->device, app->scene_index_transfer_buffer);
 
     SDL_GPUCommandBuffer *upload_cmdbuf = SDL_AcquireGPUCommandBuffer(app->device);
@@ -1796,7 +1796,7 @@ static void update_game(GameApp *app) {
     if (app->overlay_vertex_count > 0) {
         OverlayVertex *mapped = (OverlayVertex *)SDL_MapGPUTransferBuffer(app->device, app->overlay_transfer_buffer, false);
         if (mapped) {
-            base_memmove(mapped, app->overlay_cpu_vertices, sizeof(OverlayVertex) * app->overlay_vertex_count);
+            base_memcpy(mapped, app->overlay_cpu_vertices, sizeof(OverlayVertex) * app->overlay_vertex_count);
             SDL_UnmapGPUTransferBuffer(app->device, app->overlay_transfer_buffer);
         }
     }

--- a/game.html
+++ b/game.html
@@ -98,6 +98,17 @@ const stdoutDecoder = new TextDecoder();
             sdlHost.setMemory(wasmMemory);
             wasiFs.setMemory(wasmMemory);
 
+            // Pass buddy allocator functions to SDL host for GPU buffer allocation
+            if (wasmInstance.exports.wasm_buddy_alloc && wasmInstance.exports.wasm_buddy_free) {
+                sdlHost.setBuddyAllocFunctions(
+                    wasmInstance.exports.wasm_buddy_alloc,
+                    wasmInstance.exports.wasm_buddy_free
+                );
+                console.log('[Init] Buddy allocator functions bound');
+            } else {
+                console.error('[Init] Missing buddy allocator exports!');
+            }
+
             // Call main
             const app_init = wasmInstance.exports.app_init;
             const app_iterate = wasmInstance.exports.app_iterate;


### PR DESCRIPTION
It was overlapping previously and colliding. Now the memory allocated from JavaScript inside the WASM module is separate from other internal memory.